### PR TITLE
Fix invalid syntax in script 2

### DIFF
--- a/activedeploy_step_2.sh
+++ b/activedeploy_step_2.sh
@@ -16,7 +16,7 @@
 #********************************************************************************
 
 #set $DEBUG to 1 for set -x output
-if [ $DEBUG -eq 1 ]; then
+if [[ -n ${DEBUG} ]]; then
   set -x # trace steps
 fi
 


### PR DESCRIPTION
error trace from bluemix:

```
Cloning into 'activedeploy'...
activedeploy/activedeploy_step_2.sh: line 19: [: -eq: unary operator expected
```

This uses the syntax from script 1 to enable debug in script 2
