### PR TITLE
issue 215 - add link to full AD GUI in AD pipeline logs

### DIFF
--- a/activedeploy_step_1.sh
+++ b/activedeploy_step_1.sh
@@ -66,7 +66,8 @@ function exit_with_link() {
       full_GUI_URL="${target_url}/services/${ad_service_guid}?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}"
       show_link "Deployment URL" ${full_GUI_URL} ${green}
   else
-      show_link "Deployment URL" ${update_url} ${__color}
+      logInfo "No Active Deploy GUI available on this environment."
+      #show_link "Deployment URL" ${update_url} ${__color}
   fi
 
   exit ${__status}
@@ -261,9 +262,9 @@ if [[ -n "${original_grp}" ]]; then
     full_GUI_URL="${target_url}/services/${ad_service_guid}?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}"
     show_link "Deployment URL" ${full_GUI_URL} ${green}
   else
-    # no full AD GUI and no AD Instance available, show snippet GUI
-    update_url="${update_gui_url}/deployments/${update}?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}"
-    show_link "Deployment URL" "${update_url}" ${green}
+    logInfo "No Active Deploy GUI available on this environment."
+    #update_url="${update_gui_url}/deployments/${update}?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}"
+    #show_link "Deployment URL" "${update_url}" ${green}
   fi
 
   # Identify toolchain if available and send update details to it

--- a/activedeploy_step_2.sh
+++ b/activedeploy_step_2.sh
@@ -78,9 +78,8 @@ if [[ ${ad_service_guid} && ${target_url} ]]; then
     full_GUI_URL="${target_url}/services/${ad_service_guid}?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}"
     show_link "Deployments for space ${CF_SPACE_ID}" ${full_GUI_URL} ${green}
 else
-    show_link "Deployment URL" \
-    "${update_gui_url}/deployments/${update_id}?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}" \
-    ${green}
+    logInfo "No Active Deploy GUI available on this environment."
+    #show_link "Deployment URL" "${update_gui_url}/deployments/${update_id}?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}" ${green}
 fi
 
 logInfo "Not initial version (part of update ${update_id})"

--- a/check_and_set_env.sh
+++ b/check_and_set_env.sh
@@ -221,13 +221,13 @@ case "${update_gui_url}" in
   target_url="https://new-console.ng.bluemix.net"
   ;;
   https://activedeploy.stage1.ng.bluemix.net) # STAGE1
-  target_url="https://dev-console.stage1.ng.mybluemix.net"
+  target_url="https://dev-console.stage1.ng.bluemix.net"
   ;;
   https://activedeploy.eu-gb.bluemix.net) # LONDON Prod
   target_url="https://new-console.eu-gb.bluemix.net"
   ;;
   *) # In case of AD full UI not available
-  logInfo "Full AD GUI URL could not be determined, use AD GUI snippet"
-  show_link "check script: Deployments for space ${CF_SPACE_ID}" "${update_gui_url}/deployments?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}" ${green}
+  logInfo "No Active Deploy GUI available on this environment."
+  # show_link "check script: Deployments for space ${CF_SPACE_ID}" "${update_gui_url}/deployments?ace_config={%22spaceGuid%22:%22${CF_SPACE_ID}%22}" ${green}
   ;;
 esac


### PR DESCRIPTION
wi: https://github.ibm.com/ActiveDeploy/team/issues/215

correction in target url and changes in case of deploy target is london prod
